### PR TITLE
Document update ngrok

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ On the .env file:
 
 Replace the value of **NEXTAUTH_URL** variable with your new url
 
-
 ### Run the local cron worker
 
 There is a way to run a local cron worker that will trigger all scheduled runs when developing locally


### PR DESCRIPTION
Adds  a "how to" section on README on what you need to do if you restart och somehow get a new url from Ngrok.
fixes #35 