### PR TITLE
Improve local docker setup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,7 @@
 FROM node:18-alpine
 
 WORKDIR /app
-
 COPY package.json yarn.lock prisma/ ./
 
-RUN yarn install
-RUN yarn postinstall
+RUN yarn install && yarn cache clean
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - db-shadow:/var/lib/mysql
   frontend:
+    image: workflow-manager-dev
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -38,11 +39,10 @@ services:
       NODE_ENV: development
       DATABASE_URL: "mysql://dev:password@main-mysql:3306/dev"
   cron:
+    image: workflow-manager-dev
+    pull_policy: never
     depends_on:
       - frontend
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
     command: yarn run-cron
     volumes:
       - .:/app


### PR DESCRIPTION
## Describe your changes

Remove the yarn cache from the image to reduce the size.
Use the same image for both the frontend and the cron container, and only
build it once.

## Issue ticket number or discussion
<!--- Add your issue link or existing ideas discussion [here](https://github.com/codelabsab/workflow-manager/discussions/categories/ideas) --->
N/A