### PR TITLE
Update unstable_getServerSession -> getServerSession

### DIFF
--- a/src/server/common/get-server-auth-session.ts
+++ b/src/server/common/get-server-auth-session.ts
@@ -1,15 +1,15 @@
 import { type GetServerSidePropsContext } from "next";
-import { unstable_getServerSession } from "next-auth";
+import { getServerSession } from "next-auth";
 
 import { authOptions } from "../../pages/api/auth/[...nextauth]";
 
 /**
- * Wrapper for unstable_getServerSession https://next-auth.js.org/configuration/nextjs
+ * Wrapper for getServerSession https://next-auth.js.org/configuration/nextjs
  * See example usage in trpc createContext or the restricted API route
  */
 export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
+  return await getServerSession(ctx.req, ctx.res, authOptions);
 };


### PR DESCRIPTION
## Describe your changes

According to
https://next-auth.js.org/configuration/nextjs#unstable_getserversession
it has been renamed to getServerSession

